### PR TITLE
Fix: add a nil check before accessing response_headers[:'Retry-After']

### DIFF
--- a/lib/klaviyo-api-sdk.rb
+++ b/lib/klaviyo-api-sdk.rb
@@ -925,7 +925,7 @@ module KlaviyoAPI
           end
         rescue KlaviyoAPI::ApiError => exception
           last_exception = exception
-          last_request_retry_after = exception.response_headers[:'Retry-After']
+          last_request_retry_after = exception.response_headers && exception.response_headers[:'Retry-After']
           last_request_timestamp = Time.now
           raise unless [429, 503, 504, 524].include? exception.code
         end


### PR DESCRIPTION
When a connection timeout occurs it raises an `ApiError` with nil response headers. However, in the `with_retry` method, the code attempts to access `response_headers[:'Retry-After']` without checking if response_headers is nil, causing an error
```
gems/klaviyo-api-sdk-13.0.1/lib/klaviyo-api-sdk.rb:928:in `rescue in with_retry': undefined method `[]' for nil:NilClass
          last_request_retry_after = exception.response_headers[:'Retry-After']
                                                               ^^^^^^^^^^^^^^^^ 
```